### PR TITLE
direct access broken link labor certification

### DIFF
--- a/src/app/profile/profile.tpl.html
+++ b/src/app/profile/profile.tpl.html
@@ -372,7 +372,7 @@
 						<a href="#">Autoservicios</a>
 					</li>
 					<li class="current">
-						<a href="#">Certificado de Ingresos y retenciones</a>
+						<a href="#">Certificado de Ingresos y retenciones </a>
 					</li>
 				</ul>
 			</div>
@@ -380,7 +380,7 @@
 		<div class="large-5 medium-5 columns" ng-if="certificatesRoute(ubicacion)">
 			<ul class="inline-list linemenu">
 				<li>
-					<a ui-sref="main.views.certificates_labor({id:0})" data-tooltip aria-haspopup="true" title="Certificado Laboral">
+					<a ui-sref="main.views.certificates_labor({id:laborCertificate})" data-tooltip aria-haspopup="true" title="Certificado Laboral">
 						<i class="fa fa-file-text-o fa-lg"></i>
 					</a>
 				</li>


### PR DESCRIPTION
broken link icons of certificates, labor certification was misdirected the disadvantage is corrected by adding the parameter 'id: laborCertificate' the call controller
