### PR TITLE
special capitalize

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -178,9 +178,9 @@
       var words = value.split(" ");
       var newValue = "";
       var newWord;
-      var exceptionsAcronyms = ['TI'];
+      var exceptionsAcronyms = ['TI','BTL'];
       angular.forEach(words,function(word,iWord){
-        if (exceptionsAcronyms.indexOf(word) != -1){
+        if (exceptionsAcronyms.indexOf(word.toUpperCase()) != -1){
           newWord = word.toUpperCase()+" ";;
         }else if((word.length == 1 || word.length == 2 || word.length == 3) && type!="own"){
           newWord = word.toLowerCase()+" ";

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -182,7 +182,7 @@
       angular.forEach(words,function(word,iWord){
         if (exceptionsAcronyms.indexOf(word.toUpperCase()) != -1){
           newWord = word.toUpperCase()+" ";;
-        }else if((word.length == 1 || word.length == 2 || word.length == 3) && type!="own"){
+        }else if((word.length > 0 && word.length <= 3) && type!="own"){
           newWord = word.toLowerCase()+" ";
         }else{
           newWord = word.substring(0,1).toUpperCase() + word.substring(1).toLowerCase()+" ";

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -172,6 +172,26 @@
        return value.toLowerCase();
     }
   })
+  .filter('special_capitalize',function(){
+    return function (value,type){
+      if (!value) return '';
+      var words = value.split(" ");
+      var newValue = "";
+      var newWord;
+      var exceptionsAcronyms = ['TI'];
+      angular.forEach(words,function(word,iWord){
+        if (exceptionsAcronyms.indexOf(word) != -1){
+          newWord = word.toUpperCase()+" ";;
+        }else if((word.length == 1 || word.length == 2 || word.length == 3) && type!="own"){
+          newWord = word.toLowerCase()+" ";
+        }else{
+          newWord = word.substring(0,1).toUpperCase() + word.substring(1).toLowerCase()+" ";
+        }
+        newValue = newValue.concat(newWord);
+      });
+      return newValue;
+    }
+  })
   .run(function($filter, $http, $rootScope, $state, $window, HRAPI_CONF, $auth , $anchorScroll, $location){       
       
     /////////////

--- a/src/app/dashboard/dashboard.tpl.html
+++ b/src/app/dashboard/dashboard.tpl.html
@@ -229,10 +229,10 @@
 									</div>
 									<h6 class="no-margin capitalize">
 										<a ui-sref="main.views.employee_info_lookup({id:empleado.identification, c:empleado.company.id})">
-											{{empleado.lastname | lowercase}} {{empleado.name | lowercase}}
+											{{empleado.lastname | special_capitalize:'own'}} {{empleado.name | special_capitalize:'own'}}
 										</a>
 									</h6>
-									<h6 class="subheader no-margin capitalize">{{empleado.posicion | lowercase}}</h6>
+									<h6 class="subheader no-margin">{{empleado.posicion | special_capitalize }}</h6>
 									<div class="text-right">
 										<span class="graytxt">
 											<i class="fa fa-calendar-o"></i>
@@ -272,9 +272,9 @@
 											<img alt="profile" ng-src="{{empleado.image.url}}">
 										</a>
 									</div>
-									<h6 class="no-margin capitalize">
+									<h6 class="no-margin">
 										<a ui-sref="main.views.employee_info_lookup({id:empleado.identification, c:empleado.company.id})">
-										{{empleado.lastname | lowercase}} {{empleado.name | lowercase}}
+										{{empleado.lastname | special_capitalize:'own'}} {{empleado.name | special_capitalize:'own'}}
 										</a>
 									</h6>						
 <!--									<h6 class="subheader no-margin capitalize">{{empleado.posicion | lowercase}}</h6>-->
@@ -319,12 +319,12 @@
 											<img alt="profile" ng-src="{{empleado.image.url}}">
 										</a>
 									</div>
-									<h6 class="no-margin capitalize">
+									<h6 class="no-margin">
 										<a ui-sref="main.views.employee_info_lookup({id:empleado.identification, c:empleado.company.id})">
-											{{empleado.lastname | lowercase}} {{empleado.name | lowercase}}
+											{{empleado.lastname | special_capitalize:'own'}} {{empleado.name | special_capitalize:'own'}}
 										</a>
 									</h6>
-									<h6 class="subheader no-margin capitalize">{{empleado.posicion | lowercase}}</h6>
+									<h6 class="subheader no-margin">{{empleado.posicion | special_capitalize }}</h6>
 									<div class="text-right">
 										<span class="graytxt">
 											<i class="fa fa-calendar-o"></i>

--- a/src/app/organigram/organigram.tpl.html
+++ b/src/app/organigram/organigram.tpl.html
@@ -7,8 +7,8 @@
 						<a><img ng-src="{{image_organigram(organigram.image.image.url)}}" alt="" /></a>
 					</div>
 					<div class="org-info">
-						<h4 class="no-margin maxup bluetxt">{{organigram.short_name | lowercase}}</h4>
-						<h5 class="no-margin maxup">{{organigram.posicion | lowercase}}</h5>
+						<h4 class="no-margin maxup bluetxt">{{organigram.short_name | special_capitalize:'own'}}</h4>
+						<h5 class="no-margin maxup">{{organigram.posicion | special_capitalize}}</h5>
 					</div>
 					<ul class="no-bullet">
 						<li ng-repeat="(key, employee) in organigram.children">
@@ -24,8 +24,8 @@
 								<a><img ng-src="{{image_organigram(employee.image.image.url)}}" alt="" /></a>
 							</div>
 							<div class="org-info hovered" ng-click="mostrar($event)">
-								<h5 class="no-margin maxup">{{employee.short_name | lowercase}}</h5>
-								<h6 class="no-margin maxup">{{employee.posicion | lowercase}}</h6>
+								<h5 class="no-margin maxup">{{employee.short_name | special_capitalize:'own'}}</h5>
+								<h6 class="no-margin maxup">{{employee.posicion | special_capitalize }}</h6>
 							</div>
 
 							<ul class="childs no-bullet" ng-if="employee.children || employee._children">
@@ -34,8 +34,8 @@
 										<a><img ng-src="{{image_organigram(razo.image.url)}}" alt="" /></a>
 									</div>
 									<div class="org-info">
-										<h5 class="no-margin subheader maxup fixdown">{{razo.short_name | lowercase}}</h5>
-										<h6 class="no-margin subheader maxup">{{razo.posicion | lowercase}}</h6>
+										<h5 class="no-margin subheader maxup fixdown">{{razo.short_name | special_capitalize:'own' }}</h5>
+										<h6 class="no-margin subheader maxup">{{razo.posicion | special_capitalize}}</h6>
 									</div>
 								</li>
 								<li ng-repeat="razo in employee._children">

--- a/src/app/sidebar/sidebar.tpl.html
+++ b/src/app/sidebar/sidebar.tpl.html
@@ -33,7 +33,7 @@
 				{{employee.name | lowercase}} {{employee.lastname | lowercase}}
 			</div>
 		</h6>
-		<h6 class="no-margin subheader cargo capitalize contact-name" title="{{employee.posicion | lowercase}}" ng-click="showModal(employee)">{{employee.posicion  | autoAdjusts}}</h6>
+		<h6 class="no-margin subheader cargo capitalize contact-name" title="{{employee.posicion | special_capitalize }}" ng-click="showModal(employee)">{{employee.posicion  | autoAdjusts | special_capitalize }}</h6>
 			<div class="action-buttons">
 				<div ng-if="!isRcnTv()">
 					<a ng-if="employee.phone" href="tel://{{employee.phone}}" data-tooltip aria-haspopup="true" title="{{employee.phone}}">
@@ -74,7 +74,7 @@
 				{{employee.name | lowercase}} {{employee.lastname | lowercase}}
 			</div>
 		</h6>
-		<h6 class="no-margin subheader cargo capitalize  contact-name" title="{{employee.posicion | lowercase}}" ng-click="showModal(employee)">{{employee.posicion  | autoAdjusts}}</h6>
+		<h6 class="no-margin subheader cargo contact-name" title="{{employee.posicion | special_capitalize }}" ng-click="showModal(employee)">{{employee.posicion | autoAdjusts | special_capitalize  }}</h6>
 		<div class="action-buttons">
 			<div ng-if="!isRcnTv()">
 				<a ng-if="employee.phone" href="tel://{{employee.phone}}" data-tooltip aria-haspopup="true" title="{{employee.phone}}">

--- a/src/assets/styles/custom.scss
+++ b/src/assets/styles/custom.scss
@@ -311,7 +311,6 @@
 	list-style-type: none;
 	li{
 		h6.cargo{
-			text-transform: capitalize;
 			position: relative;
 			top: -3px;
 			max-width: 150px;
@@ -1105,7 +1104,6 @@ li .pictuare:hover img {
 
 .maxup{
   max-width: 350px;
-  text-transform: capitalize;
   overflow: hidden;
 }
 


### PR DESCRIPTION
filter is created to capitalize specially except connectors, parameter type is added, if you find the word 'own' is capitalizing normal since they are proper names, also an array of exceptions to include there acronyms that should be in capital letters is created, example 'TI'.

the filter sections as dashboard and favorite is applied, styles that interfered with the use of filter classes as 'MAXUP' and 'h6.cargo' was verified that not affect other sections removed.
